### PR TITLE
Adding place to hold contain test helper

### DIFF
--- a/index.js
+++ b/index.js
@@ -331,6 +331,13 @@ Test.prototype = {
       test.is[method] = test.assert[method].bind(test.assert);
       test.assert.is[method] = test.assert[method].bind(test.assert);
     });
+    ['contain'].forEach(function (method) {
+      test.to = {};
+      test.assert.to = {};
+
+      test.to[method] = test.assert[method].bind(test.assert);
+      test.assert.to[method] = test.assert[method].bind(test.assert);
+    });
     return test;
   },
 


### PR DESCRIPTION
Part of the commit to add to.contain() test helper method which is useful for test things that are dynamic but parts can be safely assume.  A specific case would be making sure a certain class exist when you might not know all the classes or the order the classes are in.
