### PR TITLE
Added like test helper for case-insensitive testing

### DIFF
--- a/index.js
+++ b/index.js
@@ -327,7 +327,7 @@ Test.prototype = {
    */
 
   _inheritAssertionHelpers: function (test) {
-    ['not', 'between', 'gt', 'gte', 'lt', 'lte', 'like'].forEach(function (method) {
+    ['not', 'between', 'gt', 'gte', 'lt', 'lte', 'equalsCaseInsensitive'].forEach(function (method) {
       test.is[method] = test.assert[method].bind(test.assert);
       test.assert.is[method] = test.assert[method].bind(test.assert);
     });


### PR DESCRIPTION
Part of the commit to add is.like() test helper method which allows for case-insensitive testing 
