### PR TITLE
Added match() helper method to be able to test with regexes (#3)

### DIFF
--- a/index.js
+++ b/index.js
@@ -360,9 +360,9 @@ Test.prototype = {
       test.is[method] = test.assert[method].bind(test.assert);
       test.assert.is[method] = test.assert[method].bind(test.assert);
     });
-    ['contain'].forEach(function (method) {
-      test.to = {};
-      test.assert.to = {};
+    ['contain', 'match'].forEach(function (method) {
+      test.to = test.to || {};
+      test.assert.to = test.assert.to || {};
 
       test.to[method] = test.assert[method].bind(test.assert);
       test.assert.to[method] = test.assert[method].bind(test.assert);


### PR DESCRIPTION
This adds the match() helper in order to be able to use regexes with tests.  This close issue #3.
